### PR TITLE
#45 Fixed hard coded cache size. The cache size is now read from default.toml

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	SliceSize      uint   `toml:"slice_size"`
 	CacheSize      uint   `toml:"cache_size"`
 	SliceCacheSize uint   `toml:"slice_cache_size"`
-	Port           int    `toml:"port"`
+	Port           uint    `toml:"port"`
 }
 
 var config *Config
@@ -69,7 +69,7 @@ func (c *Config) GetSliceCacheSize() uint {
 /*
 GetPort returns the port the server runs on
 */
-func (c *Config) GetPort() int {
+func (c *Config) GetPort() uint {
 	return c.Port
 }
 
@@ -115,7 +115,8 @@ func GetConfig() *Config {
 			}
 		}
 
-		port, err := strconv.Atoi(strings.TrimSpace(os.Getenv("COUNTS_PORT")))
+		portInt, err := strconv.Atoi(strings.TrimSpace(os.Getenv("COUNTS_PORT")))
+		port := uint(portInt)
 		if err != nil {
 			port = config.Port
 		}

--- a/config/default.toml
+++ b/config/default.toml
@@ -8,7 +8,7 @@ data_dir = "~/.counts/data"
 slice_size = 5
 
 # num of counters in cache
-cache_size = 2
+cache_size = 250
 
 # number slices in the slice cache
 slice_cache_size = 1

--- a/server/server.go
+++ b/server/server.go
@@ -150,7 +150,7 @@ Run ...
 */
 func (srv *Server) Run() {
 	conf := config.GetConfig()
-	port := conf.GetPort()
+	port := int(conf.GetPort())
 	logger.Info.Println("Server up and running on port: " + strconv.Itoa(port))
 	http.ListenAndServe(":"+strconv.Itoa(port), srv)
 }

--- a/storage/manager.go
+++ b/storage/manager.go
@@ -35,8 +35,11 @@ func onFileEvicted(k interface{}, v interface{}) {
 func newManager() *ManagerStruct {
 	conf = config.GetConfig()
 	dataPath = conf.GetDataDir()
-	//FIXME: size of cache should be read from config
-	cache, err := lru.NewWithEvict(250, onFileEvicted)
+	var cacheSize int = int(conf.GetCacheSize())
+	if cacheSize == 0 {
+		cacheSize = 250 // default cache size
+	}
+	cache, err := lru.NewWithEvict(cacheSize, onFileEvicted)
 	utils.PanicOnError(err)
 	err = os.MkdirAll(dataPath, 0777)
 	utils.PanicOnError(err)


### PR DESCRIPTION
No more hard coded cache size. Now the cache size is being read from the default config.