### PR TITLE
Added a wrapper for the count-min-log implementation by seiflotfy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
  - go get github.com/BurntSushi/toml
  - go get code.google.com/p/gofarmhash
  - go get github.com/boltdb/bolt
+ - go get github.com/seiflotfy/count-min-log
 
 script:
  - go test -v ./...

--- a/counters/wrappers/count-min-log/count-min-log/LICENSE
+++ b/counters/wrappers/count-min-log/count-min-log/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Seif Lotfy <seif.lotfy@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/counters/wrappers/count-min-log/count-min-log/README.md
+++ b/counters/wrappers/count-min-log/count-min-log/README.md
@@ -1,0 +1,44 @@
+# Count-Min-Log
+[![GoDoc](https://godoc.org/github.com/seiflotfy/count-min-log?status.svg)](https://godoc.org/github.com/seiflotfy/count-min-log)
+
+[Count-Min-Log sketch: Approximately counting with approximate counters - Guillaume Pitel & Geoffroy Fouquier](http://iswag-symposium.org/2015/pdfs/shortpaper1.pdf)
+
+<b>TL;DR:</b> Count-Min-Log Sketch for improved Average Relative Error on low frequency events
+
+Count-Min Sketch is a widely adopted algorithm for approximate event counting in large scale processing. However, the original version of the Count-Min-Sketch (CMS) suffers of some deficiences, especially if one is interested in the low-frequency items, such as in text- mining related tasks. Several variants of CMS have been proposed to compensate for the high relative error for low-frequency events, but the proposed solutions tend to correct the errors instead of preventing them. In this paper, we propose the Count-Min-Log sketch, which uses logarithm-based, approximate counters instead of linear counters to improve the average relative error of CMS at constant memory footprint.
+
+## Example Usage
+
+8-bit version
+
+```go
+import cml
+
+...
+
+sk, err := cml.NewDefaultSketch8()
+sk.IncreaseCount([]byte("scott pilgrim"))
+...
+
+sk.GetCount("scott pilgrim")
+
+// >> 1
+
+```
+
+16-bit version
+
+```go
+import cml
+
+...
+
+sk, err := cml.NewDefaultSketch16()
+sk.IncreaseCount([]byte("scott pilgrim"))
+...
+
+sk.GetCount("scott pilgrim")
+
+// >> 1
+
+```

--- a/counters/wrappers/count-min-log/count-min-log/doc.go
+++ b/counters/wrappers/count-min-log/count-min-log/doc.go
@@ -1,0 +1,32 @@
+/*
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
+Package cml implments the Count-Min-Log datastructure.
+
+It is based on Count-Min-Log sketch: Approximately counting with approximate counters - Guillaume Pitel & Geoffroy Fouquier
+
+http://iswag-symposium.org/2015/pdfs/shortpaper1.pdf
+
+TL;DR: Count-Min-Log Sketch for improved Average Relative Error on low frequency events
+
+Count-Min Sketch is a widely adopted algorithm for approximate event counting in large scale processing. However, the original version of the Count-Min-Sketch (CMS) suffers of some deficiences, especially if one is interested in the low-frequency items, such as in text- mining related tasks. Several variants of CMS have been proposed to compensate for the high relative error for low-frequency events, but the proposed solutions tend to correct the errors instead of preventing them. In this paper, we propose the Count-Min-Log sketch, which uses logarithm-based, approximate counters instead of linear counters to improve the average relative error of CMS at constant memory footprint.
+*/
+package cml

--- a/counters/wrappers/count-min-log/count-min-log/log16.go
+++ b/counters/wrappers/count-min-log/count-min-log/log16.go
@@ -1,0 +1,172 @@
+package cml
+
+import (
+	"errors"
+	"math"
+	"math/rand"
+)
+
+func value16(c uint16, exp float64) float64 {
+	if c == 0 {
+		return 0.0
+	}
+	return math.Pow(exp, float64(c-1))
+}
+
+func fullValue16(c uint16, exp float64) float64 {
+	if c <= 1 {
+		return value16(c, exp)
+	}
+	return (1.0 - value16(c+1, exp)) / (1.0 - exp)
+}
+
+/*
+Sketch16 is a Count-Min-Log sketch 16-bit registers
+*/
+type Sketch16 struct {
+	w            uint
+	k            uint
+	conservative bool
+	exp          float64
+	maxSample    bool
+	progressive  bool
+	nBits        uint
+
+	store      [][]uint16
+	totalCount uint
+	cMax       float64
+}
+
+/*
+NewSketch16 returns a new Count-Min-Log sketch with 16-bit registers
+*/
+func NewSketch16(w uint, k uint, conservative bool, exp float64,
+	maxSample bool, progressive bool, nBits uint) (*Sketch16, error) {
+	store := make([][]uint16, k)
+	for i := uint(0); i < k; i++ {
+		store[i] = make([]uint16, w)
+	}
+	cMax := math.Pow(2.0, float64(nBits)) - 1.0
+	if cMax > math.MaxUint16 {
+		return nil,
+			errors.New("using 16 bit registers allows a max nBits value of 16")
+	}
+	return &Sketch16{
+		w:            w,
+		k:            k,
+		conservative: conservative,
+		exp:          exp,
+		maxSample:    maxSample,
+		progressive:  progressive,
+		nBits:        nBits,
+		store:        store,
+		totalCount:   0.0,
+		cMax:         cMax,
+	}, nil
+}
+
+/*
+NewDefaultSketch16 ...
+*/
+func NewDefaultSketch16() (*Sketch16, error) {
+	return NewSketch16(1000000, 10, true, 1.00026, true, true, 16)
+}
+
+func (sk *Sketch16) randomLog(c uint16, exp float64) bool {
+	pIncrease := 1.0 / (fullValue16(c+1, sk.getExp(c+1)) - fullValue16(c, sk.getExp(c)))
+	return rand.Float64() < pIncrease
+}
+
+func (sk *Sketch16) getExp(c uint16) float64 {
+	if sk.progressive == true {
+		return 1.0 + ((sk.exp - 1.0) * (float64(c) - 1.0) / sk.cMax)
+	}
+	return sk.exp
+}
+
+/*
+Reset the Sketch to a fresh state (all counters set to 0)
+*/
+func (sk *Sketch16) Reset() {
+	sk.store = make([][]uint16, sk.k)
+	for i := uint(0); i < sk.k; i++ {
+		sk.store[i] = make([]uint16, sk.w)
+	}
+	sk.totalCount = 0
+}
+
+/*
+IncreaseCount increases the count of `s` by one, return true if added and the current count of `s`
+*/
+func (sk *Sketch16) IncreaseCount(s []byte) (bool, float64) {
+	sk.totalCount++
+	v := make([]uint16, sk.k)
+	vmin := uint16(math.MaxUint16)
+	vmax := uint16(0)
+	for i := range v {
+		v[i] = sk.store[i][hash(s, uint(i), sk.w)]
+		if v[i] < vmin {
+			vmin = v[i]
+		}
+		if v[i] > vmax {
+			vmax = v[i]
+		}
+	}
+
+	var c uint16
+	if sk.maxSample {
+		c = vmax
+	} else {
+		c = vmin
+	}
+
+	if float64(c) > sk.cMax {
+		return false, 0.0
+	}
+
+	increase := sk.randomLog(c, 0.0)
+	if increase {
+		for i := uint(0); i < sk.k; i++ {
+			nc := v[i]
+			if !sk.conservative || vmin == nc {
+				sk.store[i][hash(s, i, sk.w)] = nc + 1
+			}
+		}
+		return increase, fullValue16(vmin+1, sk.getExp(vmin+1))
+	}
+	return false, fullValue16(vmin, sk.getExp(vmin))
+}
+
+/*
+GetCount returns the count of `s`
+*/
+func (sk *Sketch16) GetCount(s []byte) float64 {
+	cl := make([]uint16, sk.k)
+	clmin := uint16(math.MaxUint16)
+	for i := uint(0); i < sk.k; i++ {
+		cl[i] = sk.store[i][hash(s, i, sk.w)]
+		if cl[i] < clmin {
+			clmin = cl[i]
+		}
+	}
+	c := clmin
+	return fullValue16(c, sk.getExp(c))
+}
+
+/*
+GetProbability returns the error probability of `s`
+*/
+func (sk *Sketch16) GetProbability(s []byte) float64 {
+	v := sk.GetCount(s)
+	if v > 0 {
+		return v / float64(sk.totalCount)
+	}
+	return 0
+}
+
+/*
+Count returns the total count
+*/
+func (sk *Sketch16) Count() uint {
+	return sk.totalCount
+}

--- a/counters/wrappers/count-min-log/count-min-log/log8.go
+++ b/counters/wrappers/count-min-log/count-min-log/log8.go
@@ -1,0 +1,178 @@
+package cml
+
+import (
+	"errors"
+	"hash/fnv"
+	"math"
+	"math/rand"
+	"strconv"
+)
+
+func value8(c uint8, exp float64) float64 {
+	if c == 0 {
+		return 0.0
+	}
+	return math.Pow(exp, float64(c-1))
+}
+
+func fullValue8(c uint8, exp float64) float64 {
+	if c <= 1 {
+		return value8(c, exp)
+	}
+	return (1.0 - value8(c+1, exp)) / (1.0 - exp)
+}
+
+func hash(s []byte, i uint, w uint) uint {
+	hasher := fnv.New32a()
+	hasher.Write(s)
+	hasher.Write([]byte(strconv.Itoa(int(i))))
+	return uint(hasher.Sum32()) % w
+}
+
+/*
+Sketch8 is a Count-Min-Log sketch 8-bit registers
+*/
+type Sketch8 struct {
+	w            uint
+	k            uint
+	conservative bool
+	exp          float64
+	maxSample    bool
+	progressive  bool
+	nBits        uint
+
+	store      [][]uint8
+	totalCount uint
+	cMax       float64
+}
+
+/*
+NewSketch8 returns a new Count-Min-Log sketch with 8-bit registers
+*/
+func NewSketch8(w uint, k uint, conservative bool, exp float64,
+	maxSample bool, progressive bool, nBits uint) (*Sketch8, error) {
+	store := make([][]uint8, k)
+	for i := uint(0); i < k; i++ {
+		store[i] = make([]uint8, w)
+	}
+	cMax := math.Pow(2.0, float64(nBits)) - 1.0
+	if cMax > math.MaxUint8 {
+		return nil,
+			errors.New("using 8 bit registers allows a max nBits value of 8")
+	}
+	return &Sketch8{
+		w:            w,
+		k:            k,
+		conservative: conservative,
+		exp:          exp,
+		maxSample:    maxSample,
+		progressive:  progressive,
+		nBits:        nBits,
+		store:        store,
+		totalCount:   0.0,
+		cMax:         cMax,
+	}, nil
+}
+
+/*
+NewDefaultSketch8 returns a new Count-Min-Log sketch with 8-bit registers and default settings
+*/
+func NewDefaultSketch8() (*Sketch8, error) {
+	return NewSketch8(1000000, 10, true, 1.5, true, true, 8)
+}
+
+func (sk *Sketch8) randomLog(c uint8, exp float64) bool {
+	pIncrease := 1.0 / (fullValue8(c+1, sk.getExp(c+1)) - fullValue8(c, sk.getExp(c)))
+	return rand.Float64() < pIncrease
+}
+
+func (sk *Sketch8) getExp(c uint8) float64 {
+	if sk.progressive == true {
+		return 1.0 + ((sk.exp - 1.0) * (float64(c) - 1.0) / sk.cMax)
+	}
+	return sk.exp
+}
+
+/*
+Reset the Sketch to a fresh state (all counters set to 0)
+*/
+func (sk *Sketch8) Reset() {
+	sk.store = make([][]uint8, sk.k)
+	for i := uint(0); i < sk.k; i++ {
+		sk.store[i] = make([]uint8, sk.w)
+	}
+	sk.totalCount = 0
+}
+
+/*
+IncreaseCount increases the count of `s` by one, return true if added and the current count of `s`
+*/
+func (sk *Sketch8) IncreaseCount(s []byte) (bool, float64) {
+	sk.totalCount++
+	v := make([]uint8, sk.k)
+	vmin := uint8(math.MaxUint8)
+	vmax := uint8(0)
+	for i := range v {
+		v[i] = sk.store[i][hash(s, uint(i), sk.w)]
+		if v[i] < vmin {
+			vmin = v[i]
+		}
+		if v[i] > vmax {
+			vmax = v[i]
+		}
+	}
+
+	var c uint8
+	if sk.maxSample {
+		c = vmax
+	} else {
+		c = vmin
+	}
+
+	if float64(c) > sk.cMax {
+		return false, 0.0
+	}
+
+	increase := sk.randomLog(c, 0.0)
+	if increase {
+		for i := uint(0); i < sk.k; i++ {
+			nc := v[i]
+			if !sk.conservative || vmin == nc {
+				sk.store[i][hash(s, i, sk.w)] = nc + 1
+			}
+		}
+		return increase, fullValue8(vmin+1, sk.getExp(vmin+1))
+	}
+	return false, fullValue8(vmin, sk.getExp(vmin))
+}
+
+/*
+GetCount returns the count of `s`
+*/
+func (sk *Sketch8) GetCount(s []byte) float64 {
+	cl := make([]uint8, sk.k)
+	clmin := uint8(math.MaxUint8)
+	for i := uint(0); i < sk.k; i++ {
+		cl[i] = sk.store[i][hash(s, i, sk.w)]
+		if cl[i] < clmin {
+			clmin = cl[i]
+		}
+	}
+	c := clmin
+	return fullValue8(c, sk.getExp(c))
+}
+
+/*
+GetProbability returns the error probability of `s`
+*/
+func (sk *Sketch8) GetProbability(s []byte) float64 {
+	v := sk.GetCount(s)
+	if v > 0 {
+		return v / float64(sk.totalCount)
+	}
+	return 0
+}
+
+func (sk *Sketch8) Count() uint {
+	return sk.totalCount
+}

--- a/counters/wrappers/count-min-log/count-min-log/log_test.go
+++ b/counters/wrappers/count-min-log/count-min-log/log_test.go
@@ -1,0 +1,145 @@
+package cml
+
+import (
+	"strconv"
+	"testing"
+)
+
+// Ensures that Add adds to the set and Count returns the correct
+// approximation.
+func TestLog8AddAndCount(t *testing.T) {
+	log, _ := NewDefaultSketch8()
+
+	log.IncreaseCount([]byte("a"))
+	log.IncreaseCount([]byte("b"))
+	log.IncreaseCount([]byte("c"))
+	log.IncreaseCount([]byte("b"))
+	log.IncreaseCount([]byte("d"))
+	log.IncreaseCount([]byte("a"))
+	log.IncreaseCount([]byte("a"))
+	if count := log.GetCount([]byte("a")); uint(count) != 3 {
+		t.Errorf("expected 3, got %d", uint(count))
+	}
+
+	if count := log.GetCount([]byte("b")); uint(count) != 2 {
+		t.Errorf("expected 2, got %d", uint(count))
+	}
+
+	if count := log.GetCount([]byte("c")); uint(count) != 1 {
+		t.Errorf("expected 1, got %d", uint(count))
+	}
+
+	if count := log.GetCount([]byte("d")); uint(count) != 1 {
+		t.Errorf("expected 1, got %d", uint(count))
+	}
+
+	if count := log.GetCount([]byte("x")); uint(count) != 0 {
+		t.Errorf("expected 0, got %d", uint(count))
+	}
+}
+
+// Ensures that Add adds to the set and Count returns the correct
+// approximation.
+func TestLog16AddAndCount(t *testing.T) {
+	log, _ := NewDefaultSketch16()
+
+	log.IncreaseCount([]byte("a"))
+	log.IncreaseCount([]byte("b"))
+	log.IncreaseCount([]byte("c"))
+	log.IncreaseCount([]byte("b"))
+	log.IncreaseCount([]byte("d"))
+	log.IncreaseCount([]byte("a"))
+	log.IncreaseCount([]byte("a"))
+	if count := log.GetCount([]byte("a")); uint(count) != 3 {
+		t.Errorf("expected 3, got %d", uint(count))
+	}
+
+	if count := log.GetCount([]byte("b")); uint(count) != 2 {
+		t.Errorf("expected 2, got %d", uint(count))
+	}
+
+	if count := log.GetCount([]byte("c")); uint(count) != 1 {
+		t.Errorf("expected 1, got %d", uint(count))
+	}
+
+	if count := log.GetCount([]byte("d")); uint(count) != 1 {
+		t.Errorf("expected 1, got %d", uint(count))
+	}
+
+	if count := log.GetCount([]byte("x")); uint(count) != 0 {
+		t.Errorf("expected 0, got %d", uint(count))
+	}
+}
+
+// Ensures that Reset restores the sketch to its original state.
+func TestLog8Reset(t *testing.T) {
+	log, _ := NewDefaultSketch8()
+	log.IncreaseCount([]byte("a"))
+	log.IncreaseCount([]byte("b"))
+	log.IncreaseCount([]byte("c"))
+	log.IncreaseCount([]byte("b"))
+	log.IncreaseCount([]byte("d"))
+	log.IncreaseCount([]byte("a"))
+	log.IncreaseCount([]byte("a"))
+
+	log.Reset()
+
+	for i := uint(0); i < log.k; i++ {
+		for j := uint(0); j < log.w; j++ {
+			if x := log.store[i][j]; x != 0 {
+				t.Errorf("expected matrix to be completely empty, got %d", x)
+			}
+		}
+	}
+}
+
+// Ensures that Reset restores the sketch to its original state.
+func TestLog16Reset(t *testing.T) {
+	log, _ := NewDefaultSketch16()
+	log.IncreaseCount([]byte("a"))
+	log.IncreaseCount([]byte("b"))
+	log.IncreaseCount([]byte("c"))
+	log.IncreaseCount([]byte("b"))
+	log.IncreaseCount([]byte("d"))
+	log.IncreaseCount([]byte("a"))
+	log.IncreaseCount([]byte("a"))
+
+	log.Reset()
+
+	for i := uint(0); i < log.k; i++ {
+		for j := uint(0); j < log.w; j++ {
+			if x := log.store[i][j]; x != 0 {
+				t.Errorf("expected matrix to be completely empty, got %d", x)
+			}
+		}
+	}
+}
+
+func BenchmarkLogAdd(b *testing.B) {
+	b.StopTimer()
+	log, _ := NewDefaultSketch8()
+	data := make([][]byte, b.N)
+	for i := 0; i < b.N; i++ {
+		data[i] = []byte(strconv.Itoa(i))
+	}
+	b.StartTimer()
+
+	for n := 0; n < b.N; n++ {
+		log.IncreaseCount(data[n])
+	}
+}
+
+func BenchmarkLogCount(b *testing.B) {
+	b.StopTimer()
+	log, _ := NewDefaultSketch8()
+	data := make([][]byte, b.N)
+	for i := 0; i < b.N; i++ {
+		data[i] = []byte(strconv.Itoa(i))
+		log.IncreaseCount([]byte(strconv.Itoa(i)))
+	}
+	b.StartTimer()
+
+	for n := 0; n < b.N; n++ {
+		log.GetCount(data[n])
+	}
+}

--- a/counters/wrappers/count-min-log/domain.go
+++ b/counters/wrappers/count-min-log/domain.go
@@ -1,0 +1,123 @@
+package cml
+
+import (
+	"encoding/json"
+	"errors"
+	"sync"
+
+	"github.com/seiflotfy/count-min-log"
+	"github.com/seiflotfy/skizze/counters/abstract"
+	"github.com/seiflotfy/skizze/storage"
+	"github.com/seiflotfy/skizze/utils"
+)
+
+var logger = utils.GetLogger()
+var manager *storage.ManagerStruct
+
+/*
+Domain is the toplevel domain to control the count-min-log implementation
+*/
+type Domain struct {
+	*abstract.Info
+	impl *cml.Sketch16
+	lock sync.RWMutex
+}
+
+/*
+NewDomain ...
+*/
+func NewDomain(info *abstract.Info) (*Domain, error) {
+	manager = storage.GetManager()
+	manager.Create(info.ID)
+	sketch16, _ := cml.NewDefaultSketch16()
+	d := Domain{info, sketch16, sync.RWMutex{}}
+	err := d.Save()
+	if err != nil {
+		logger.Error.Println("an error has occurred while saving domain: " + err.Error())
+	}
+	return &d, nil
+}
+
+/*
+NewDomainFromData ...
+*/
+func NewDomainFromData(info *abstract.Info) (*Domain, error) {
+	data, err := storage.GetManager().LoadData(info.ID, 0, 0)
+	if err != nil {
+		return nil, err
+	}
+	sketch16, _ := cml.NewDefaultSketch16()
+	// FIXME: create domain from new data
+	sketch16.GetCount(data)
+	return &Domain{info, sketch16, sync.RWMutex{}}, nil
+}
+
+/*
+Add ...
+*/
+func (d *Domain) Add(value []byte) (bool, error) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	d.impl.IncreaseCount(value)
+	d.Save()
+	return true, nil
+}
+
+/*
+AddMultiple ...
+*/
+func (d *Domain) AddMultiple(values [][]byte) (bool, error) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	for _, value := range values {
+		d.impl.IncreaseCount(value)
+	}
+	d.Save()
+	return true, nil
+}
+
+/*
+Remove ...
+*/
+func (d *Domain) Remove(value []byte) (bool, error) {
+	logger.Error.Println("This domain type does not support deletion")
+	return false, errors.New("This domain type does not support deletion")
+}
+
+/*
+RemoveMultiple ...
+*/
+func (d *Domain) RemoveMultiple(values [][]byte) (bool, error) {
+	logger.Error.Println("This domain type does not support deletion")
+	return false, errors.New("This domain type does not support deletion")
+}
+
+/*
+GetCount ...
+*/
+func (d *Domain) GetCount() uint {
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+	return uint(d.impl.Count())
+}
+
+/*
+Clear ...
+*/
+func (d *Domain) Clear() (bool, error) {
+	d.impl.Reset()
+	return true, nil
+}
+
+/*
+Save ...
+*/
+func (d *Domain) Save() error {
+	count := d.impl.Count()
+	d.Info.State["count"] = uint64(count)
+	infoData, err := json.Marshal(d.Info)
+	if err != nil {
+		return err
+	}
+	return storage.GetManager().SaveInfo(d.Info.ID, infoData)
+}


### PR DESCRIPTION
Using the implementation by seiflotfy, a wrapper has for skizze has been created. This wrapper implements all methods of the abstract domain interface besides Remove and RemoveMultiple