### PR TITLE
Refactoring

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,12 +16,14 @@ import (
 Config stores all configuration parameters for Go
 */
 type Config struct {
-	InfoDir        string `toml:"info_dir"`
-	DataDir        string `toml:"data_dir"`
-	SliceSize      uint   `toml:"slice_size"`
-	CacheSize      uint   `toml:"cache_size"`
-	SliceCacheSize uint   `toml:"slice_cache_size"`
-	Port           uint   `toml:"port"`
+	InfoDir              string `toml:"info_dir"`
+	DataDir              string `toml:"data_dir"`
+	SliceSize            uint   `toml:"slice_size"`
+	CacheSize            uint   `toml:"cache_size"`
+	SliceCacheSize       uint   `toml:"slice_cache_size"`
+	Port                 uint   `toml:"port"`
+	SaveThresholdSeconds uint   `toml:"save_threhhold_seconds"`
+	SaveThresholdOps     uint   `toml:"save_threshold_ops"`
 }
 
 var config *Config
@@ -121,6 +123,18 @@ func GetConfig() *Config {
 			port = config.Port
 		}
 
+		saveThresholdSecondsInt, err := strconv.Atoi(strings.TrimSpace(os.Getenv("SKZ_SAVE_TRESHOLD_SECS")))
+		saveThresholdSeconds := uint(saveThresholdSecondsInt)
+		if err != nil {
+			saveThresholdSeconds = config.SaveThresholdSeconds
+		}
+
+		saveThresholdOpsInt, err := strconv.Atoi(strings.TrimSpace(os.Getenv("SKZ_SAVE_TRESHOLD_OPS")))
+		saveThresholdOps := uint(saveThresholdOpsInt)
+		if err != nil {
+			saveThresholdOps = config.SaveThresholdOps
+		}
+
 		config = &Config{
 			infoDir,
 			dataDir,
@@ -128,6 +142,8 @@ func GetConfig() *Config {
 			config.CacheSize,
 			config.SliceCacheSize,
 			port,
+			saveThresholdSeconds,
+			saveThresholdOps,
 		}
 	}
 	return config

--- a/config/default.toml
+++ b/config/default.toml
@@ -15,3 +15,7 @@ slice_cache_size = 1
 
 # the port number for the server
 port = 3596
+
+# Treshold for saving a sketch to disk
+save_threshold_seconds = 5
+save_threshold_ops = 100

--- a/sketches/abstract/abstract.go
+++ b/sketches/abstract/abstract.go
@@ -10,9 +10,8 @@ type Sketch interface {
 	RemoveMultiple([][]byte) (bool, error)
 	GetCount() uint
 	Clear() (bool, error)
-	GetType() string
-	GetID() string
 	GetFrequency([][]byte) interface{}
+	Marshal() ([]byte, error)
 }
 
 /*

--- a/sketches/factory.go
+++ b/sketches/factory.go
@@ -1,0 +1,91 @@
+package sketches
+
+import (
+	"errors"
+
+	"github.com/seiflotfy/skizze/sketches/abstract"
+	"github.com/seiflotfy/skizze/sketches/wrappers/count-min-log"
+	"github.com/seiflotfy/skizze/sketches/wrappers/hllpp"
+	"github.com/seiflotfy/skizze/sketches/wrappers/topk"
+)
+
+/*
+SketchProxy ...
+*/
+type SketchProxy struct {
+	*abstract.Info
+	sketch abstract.Sketch
+}
+
+/*
+Add ...
+*/
+func (sp *SketchProxy) Add(values [][]byte) (bool, error) {
+	return sp.sketch.AddMultiple(values)
+}
+
+/*
+Remove ...
+*/
+func (sp *SketchProxy) Remove(values [][]byte) (bool, error) {
+	return sp.sketch.RemoveMultiple(values)
+}
+
+/*
+Count ...
+*/
+func (sp *SketchProxy) Count(values []string) interface{} {
+	if sp.Type == abstract.CML {
+		bvalues := make([][]byte, len(values), len(values))
+		for i, value := range values {
+			bvalues[i] = []byte(value)
+		}
+		return sp.sketch.GetFrequency(bvalues)
+	} else if sp.Type == abstract.TopK {
+		return sp.sketch.GetFrequency(nil)
+	}
+	return sp.sketch.GetCount()
+}
+
+func createSketch(info *abstract.Info) (*SketchProxy, error) {
+	var sketch abstract.Sketch
+	var err error
+
+	switch info.Type {
+	case abstract.HLLPP:
+		sketch, err = hllpp.NewSketch(info)
+	case abstract.TopK:
+		sketch, err = topk.NewSketch(info)
+	case abstract.CML:
+		sketch, err = cml.NewSketch(info)
+	default:
+		return nil, errors.New("Invalid sketch type: " + info.Type)
+	}
+	if err != nil {
+		return nil, errors.New("Error creating new sketch")
+	}
+	sp := SketchProxy{info, sketch}
+
+	return &sp, nil
+}
+
+func loadSketch(info *abstract.Info) (*SketchProxy, error) {
+	var sketch abstract.Sketch
+	var err error
+	switch info.Type {
+	case abstract.HLLPP:
+		sketch, err = hllpp.NewSketchFromData(info)
+	case abstract.TopK:
+		sketch, err = topk.NewSketchFromData(info)
+	case abstract.CML:
+		sketch, err = cml.NewSketchFromData(info)
+	default:
+		logger.Info.Println("Invalid sketch type", info.Type)
+	}
+	sp := SketchProxy{info, sketch}
+
+	if err != nil {
+		return nil, errors.New("Error creating new sketch")
+	}
+	return &sp, nil
+}

--- a/sketches/factory.go
+++ b/sketches/factory.go
@@ -1,12 +1,16 @@
 package sketches
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
+	"sync"
 
 	"github.com/seiflotfy/skizze/sketches/abstract"
 	"github.com/seiflotfy/skizze/sketches/wrappers/count-min-log"
 	"github.com/seiflotfy/skizze/sketches/wrappers/hllpp"
 	"github.com/seiflotfy/skizze/sketches/wrappers/topk"
+	"github.com/seiflotfy/skizze/storage"
 )
 
 /*
@@ -15,12 +19,17 @@ SketchProxy ...
 type SketchProxy struct {
 	*abstract.Info
 	sketch abstract.Sketch
+	lock   sync.RWMutex
+	dirty  bool
 }
 
 /*
 Add ...
 */
 func (sp *SketchProxy) Add(values [][]byte) (bool, error) {
+	sp.lock.Lock()
+	defer sp.lock.Unlock()
+	defer sp.Save()
 	return sp.sketch.AddMultiple(values)
 }
 
@@ -28,6 +37,9 @@ func (sp *SketchProxy) Add(values [][]byte) (bool, error) {
 Remove ...
 */
 func (sp *SketchProxy) Remove(values [][]byte) (bool, error) {
+	sp.lock.Lock()
+	defer sp.lock.Unlock()
+	defer sp.Save()
 	return sp.sketch.RemoveMultiple(values)
 }
 
@@ -47,9 +59,34 @@ func (sp *SketchProxy) Count(values []string) interface{} {
 	return sp.sketch.GetCount()
 }
 
+/*
+Save ...
+*/
+func (sp *SketchProxy) Save() {
+	manager := storage.GetManager()
+	serialized, err := sp.sketch.Marshal()
+	if err != nil {
+		logger.Error.Println(err)
+	}
+	err = manager.SaveData(sp.Info.ID, serialized, 0)
+	if err != nil {
+		logger.Error.Println(err)
+	}
+	info, _ := json.Marshal(sp.Info)
+	err = manager.SaveInfo(sp.Info.ID, info)
+	if err != nil {
+		logger.Error.Println(err)
+	}
+}
+
 func createSketch(info *abstract.Info) (*SketchProxy, error) {
 	var sketch abstract.Sketch
 	var err error
+	manager := storage.GetManager()
+	err = manager.Create(info.ID)
+	if err != nil {
+		return nil, errors.New("Error creating new sketch")
+	}
 
 	switch info.Type {
 	case abstract.HLLPP:
@@ -64,28 +101,40 @@ func createSketch(info *abstract.Info) (*SketchProxy, error) {
 	if err != nil {
 		return nil, errors.New("Error creating new sketch")
 	}
-	sp := SketchProxy{info, sketch}
+
+	sp := SketchProxy{info, sketch, sync.RWMutex{}, false}
+	err = storage.GetManager().Create(info.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	sp.Save()
 
 	return &sp, nil
 }
 
 func loadSketch(info *abstract.Info) (*SketchProxy, error) {
 	var sketch abstract.Sketch
-	var err error
+
+	data, err := storage.GetManager().LoadData(info.ID, 0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("Error loading data for sketch: %s", info.ID)
+	}
+
 	switch info.Type {
 	case abstract.HLLPP:
-		sketch, err = hllpp.NewSketchFromData(info)
+		sketch, err = hllpp.Unmarshal(info, data)
 	case abstract.TopK:
-		sketch, err = topk.NewSketchFromData(info)
+		sketch, err = topk.Unmarshal(info, data)
 	case abstract.CML:
-		sketch, err = cml.NewSketchFromData(info)
+		sketch, err = cml.Unmarshal(info, data)
 	default:
 		logger.Info.Println("Invalid sketch type", info.Type)
 	}
-	sp := SketchProxy{info, sketch}
+	sp := SketchProxy{info, sketch, sync.RWMutex{}, false}
 
 	if err != nil {
-		return nil, errors.New("Error creating new sketch")
+		return nil, fmt.Errorf("Error loading data for sketch: %s", info.ID)
 	}
 	return &sp, nil
 }

--- a/sketches/manager_test.go
+++ b/sketches/manager_test.go
@@ -1,11 +1,8 @@
 package sketches
 
 import (
-	"bufio"
-	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 
 	"github.com/seiflotfy/skizze/config"
@@ -212,6 +209,7 @@ func TestDumpLoadDefaultData(t *testing.T) {
 	}
 }
 
+/*
 func TestExtremeParallelDefaultCounter(t *testing.T) {
 	setupTests()
 	defer tearDownTests()
@@ -272,6 +270,7 @@ func TestExtremeParallelDefaultCounter(t *testing.T) {
 		t.Error("expected avengers count == x-men count, got", count1, "!=", count2)
 	}
 }
+*/
 
 func TestFailCreateSketch(t *testing.T) {
 	setupTests()

--- a/sketches/manager_test.go
+++ b/sketches/manager_test.go
@@ -29,6 +29,7 @@ func exists(path string) (bool, error) {
 func setupTests() {
 	os.Setenv("SKZ_DATA_DIR", "/tmp/skizze_manager_data")
 	os.Setenv("SKZ_INFO_DIR", "/tmp/skizze_manager_info")
+	os.Setenv("SKZ_SAVE_TRESHOLD_OPS", "1")
 	path, err := os.Getwd()
 	utils.PanicOnError(err)
 	path = filepath.Dir(path)

--- a/sketches/manager_test.go
+++ b/sketches/manager_test.go
@@ -1,8 +1,11 @@
 package sketches
 
 import (
+	"bufio"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/seiflotfy/skizze/config"
@@ -79,7 +82,6 @@ func TestDuplicateSketches(t *testing.T) {
 		t.Error("Expected errors while creating sketch duplicate sketch, got", err)
 	}
 }
-
 func TestDefaultCounter(t *testing.T) {
 	setupTests()
 	defer tearDownTests()
@@ -209,7 +211,6 @@ func TestDumpLoadDefaultData(t *testing.T) {
 	}
 }
 
-/*
 func TestExtremeParallelDefaultCounter(t *testing.T) {
 	setupTests()
 	defer tearDownTests()
@@ -270,7 +271,6 @@ func TestExtremeParallelDefaultCounter(t *testing.T) {
 		t.Error("expected avengers count == x-men count, got", count1, "!=", count2)
 	}
 }
-*/
 
 func TestFailCreateSketch(t *testing.T) {
 	setupTests()

--- a/sketches/wrappers/count-min-log/sketch.go
+++ b/sketches/wrappers/count-min-log/sketch.go
@@ -1,18 +1,14 @@
 package cml
 
 import (
-	"encoding/json"
 	"errors"
-	"sync"
 
 	"github.com/seiflotfy/skizze/sketches/abstract"
 	"github.com/seiflotfy/skizze/sketches/wrappers/count-min-log/count-min-log"
-	"github.com/seiflotfy/skizze/storage"
 	"github.com/seiflotfy/skizze/utils"
 )
 
 var logger = utils.GetLogger()
-var manager *storage.ManagerStruct
 
 const defaultEpsilon = 0.000003397855
 const defaultDelta = 0.99
@@ -23,18 +19,12 @@ Sketch is the toplevel Sketch to control the count-min-log implementation
 type Sketch struct {
 	*abstract.Info
 	impl *cml.Sketch16
-	lock sync.RWMutex
 }
 
 /*
 NewSketch ...
 */
 func NewSketch(info *abstract.Info) (*Sketch, error) {
-	manager = storage.GetManager()
-	err := manager.Create(info.ID)
-	if err != nil {
-		return nil, err
-	}
 	epsilon := 0.0
 	if eps, ok := info.Properties["epsilon"]; ok {
 		epsilon = eps
@@ -51,9 +41,8 @@ func NewSketch(info *abstract.Info) (*Sketch, error) {
 		info.Properties["delta"] = delta
 	}
 
-	sketch16, _ := cml.NewSketch16ForEpsilonDelta(epsilon, delta)
-	d := Sketch{info, sketch16, sync.RWMutex{}}
-	err = d.Save()
+	sketch16, err := cml.NewSketch16ForEpsilonDelta(epsilon, delta)
+	d := Sketch{info, sketch16}
 	if err != nil {
 		logger.Error.Printf("an error has occurred while saving Sketch: %s", err.Error())
 	}
@@ -61,29 +50,10 @@ func NewSketch(info *abstract.Info) (*Sketch, error) {
 }
 
 /*
-NewSketchFromData ...
-*/
-func NewSketchFromData(info *abstract.Info) (*Sketch, error) {
-	manager = storage.GetManager()
-	b, err := manager.LoadData(info.ID, 0, 0)
-	if err != nil {
-		return nil, err
-	}
-	sketch16, _ := cml.Unmarshall16(b)
-	return &Sketch{info, sketch16, sync.RWMutex{}}, nil
-}
-
-/*
 Add ...
 */
 func (d *Sketch) Add(value []byte) (bool, error) {
-	d.lock.Lock()
-	defer d.lock.Unlock()
 	d.impl.IncreaseCount(value)
-	err := d.Save()
-	if err != nil {
-		logger.Error.Println(err)
-	}
 	return true, nil
 }
 
@@ -91,14 +61,8 @@ func (d *Sketch) Add(value []byte) (bool, error) {
 AddMultiple ...
 */
 func (d *Sketch) AddMultiple(values [][]byte) (bool, error) {
-	d.lock.Lock()
-	defer d.lock.Unlock()
 	for _, value := range values {
 		d.impl.IncreaseCount(value)
-	}
-	err := d.Save()
-	if err != nil {
-		logger.Error.Println(err)
 	}
 	return true, nil
 }
@@ -135,39 +99,10 @@ func (d *Sketch) Clear() (bool, error) {
 }
 
 /*
-Save ...
+Marshal ...
 */
-func (d *Sketch) Save() error {
-	data, err := d.impl.Marshall()
-	if err != nil {
-		return err
-	}
-	err = manager.SaveData(d.Info.ID, data, 0)
-	if err != nil {
-		return err
-	}
-	count := d.impl.TotalCount()
-	d.Info.State["count"] = uint64(count)
-	infoData, err := json.Marshal(d.Info)
-	if err != nil {
-		return err
-	}
-	err = storage.GetManager().SaveInfo(d.Info.ID, infoData)
-	return err
-}
-
-/*
-GetType ...
-*/
-func (d *Sketch) GetType() string {
-	return d.Type
-}
-
-/*
-GetID ...
-*/
-func (d *Sketch) GetID() string {
-	return d.ID
+func (d *Sketch) Marshal() ([]byte, error) {
+	return d.impl.Marshall()
 }
 
 /*
@@ -180,4 +115,15 @@ func (d *Sketch) GetFrequency(values [][]byte) interface{} {
 		res[string(value)] = uint(count)
 	}
 	return res
+}
+
+/*
+Unmarshal ...
+*/
+func Unmarshal(info *abstract.Info, data []byte) (*Sketch, error) {
+	sketch16, err := cml.Unmarshall16(data)
+	if err != nil {
+		return nil, err
+	}
+	return &Sketch{info, sketch16}, nil
 }


### PR DESCRIPTION
sketch.go in wrapper now knows nothing about storage. It simply wraps the algorithm implementation in a Sketch interface. A new SketchProxy has been implemented to take care of operating and autosaving as well as loading data for the sketch from disk. It is the one that operates with the sketch interface.
Also fixes: https://github.com/seiflotfy/skizze/issues/39