### PR TITLE
Refactored Get methods from Config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,48 +33,6 @@ MaxKeySize
 */
 const MaxKeySize int = 32768 // max key size BoltDB in bytes
 
-/*
-GetInfoDir returns the top level info
-*/
-func (c *Config) GetInfoDir() string {
-	return c.InfoDir
-}
-
-/*
-GetDataDir returns the top level info
-*/
-func (c *Config) GetDataDir() string {
-	return c.DataDir
-}
-
-/*
-GetSliceSize returns the top level info
-*/
-func (c *Config) GetSliceSize() uint {
-	return c.SliceSize
-}
-
-/*
-GetCacheSize returns the top level info
-*/
-func (c *Config) GetCacheSize() uint {
-	return c.CacheSize
-}
-
-/*
-GetSliceCacheSize returns the top level info
-*/
-func (c *Config) GetSliceCacheSize() uint {
-	return c.SliceCacheSize
-}
-
-/*
-GetPort returns the port the server runs on
-*/
-func (c *Config) GetPort() uint {
-	return c.Port
-}
-
 func parseConfigTOML() *Config {
 	configPath := os.Getenv("SKZ_CONFIG")
 	if configPath == "" {
@@ -94,7 +52,7 @@ func parseConfigTOML() *Config {
 }
 
 /*
-GetConfig returns a singleton Configuration
+Config returns a singleton Configuration
 */
 func GetConfig() *Config {
 	if config == nil {

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 
 	logger.Info.Println("Starting counts...")
 	conf := config.GetConfig()
-	logger.Info.Println("Using data dir: ", conf.GetDataDir())
+	logger.Info.Println("Using data dir: ", conf.DataDir)
 	server, err := server.New()
 	utils.PanicOnError(err)
 	server.Run()

--- a/server/server.go
+++ b/server/server.go
@@ -174,7 +174,7 @@ Run ...
 */
 func (srv *Server) Run() {
 	conf := config.GetConfig()
-	port := int(conf.GetPort())
+	port := int(conf.Port)
 	logger.Info.Println("Server up and running on port: " + strconv.Itoa(port))
 	err := http.ListenAndServe(":"+strconv.Itoa(port), srv)
 	utils.PanicOnError(err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -27,10 +27,10 @@ func setupTests() {
 }
 
 func tearDownTests() {
-	os.RemoveAll(config.GetConfig().GetDataDir())
-	os.RemoveAll(config.GetConfig().GetInfoDir())
-	os.Mkdir(config.GetConfig().GetDataDir(), 0777)
-	os.Mkdir(config.GetConfig().GetInfoDir(), 0777)
+	os.RemoveAll(config.GetConfig().DataDir)
+	os.RemoveAll(config.GetConfig().InfoDir)
+	os.Mkdir(config.GetConfig().DataDir, 0777)
+	os.Mkdir(config.GetConfig().InfoDir, 0777)
 	storage.CloseInfoDB()
 	sketchesManager.Destroy()
 }

--- a/sketches/factory.go
+++ b/sketches/factory.go
@@ -96,7 +96,7 @@ func (sp *SketchProxy) save(force bool) {
 	if sp.ops%config.GetConfig().SaveThresholdOps == 0 || force {
 		sp.ops++
 		sp.dirty = false
-		manager := storage.GetManager()
+		manager := storage.Manager()
 		serialized, err := sp.sketch.Marshal()
 		if err != nil {
 			logger.Error.Println(err)
@@ -116,7 +116,7 @@ func (sp *SketchProxy) save(force bool) {
 func createSketch(info *abstract.Info) (*SketchProxy, error) {
 	var sketch abstract.Sketch
 	var err error
-	manager := storage.GetManager()
+	manager := storage.Manager()
 	err = manager.Create(info.ID)
 	if err != nil {
 		return nil, errors.New("Error creating new sketch")
@@ -141,7 +141,7 @@ func createSketch(info *abstract.Info) (*SketchProxy, error) {
 	}
 
 	sp := SketchProxy{info, sketch, sync.RWMutex{}, 0, true}
-	err = storage.GetManager().Create(info.ID)
+	err = storage.Manager().Create(info.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func createSketch(info *abstract.Info) (*SketchProxy, error) {
 func loadSketch(info *abstract.Info) (*SketchProxy, error) {
 	var sketch abstract.Sketch
 
-	data, err := storage.GetManager().LoadData(info.ID, 0, 0)
+	data, err := storage.Manager().LoadData(info.ID, 0, 0)
 	if err != nil {
 		return nil, fmt.Errorf("Error loading data for sketch: %s", info.ID)
 	}

--- a/sketches/manager.go
+++ b/sketches/manager.go
@@ -72,7 +72,7 @@ func (m *ManagerStruct) DeleteSketch(sketchID string, sketchType string) error {
 	}
 	delete(m.sketches, id)
 	delete(m.info, id)
-	manager := storage.GetManager()
+	manager := storage.Manager()
 	err := manager.DeleteInfo(id)
 	if err != nil {
 		return err
@@ -184,7 +184,7 @@ func newManager() (*ManagerStruct, error) {
 func (m *ManagerStruct) dumpInfo(info *abstract.Info) {
 	// FIXME: Should we panic here?
 	m.info[info.ID] = info
-	manager := storage.GetManager()
+	manager := storage.Manager()
 	infoData, err := json.Marshal(info)
 	utils.PanicOnError(err)
 	err = manager.SaveInfo(info.ID, infoData)
@@ -192,7 +192,7 @@ func (m *ManagerStruct) dumpInfo(info *abstract.Info) {
 }
 
 func (m *ManagerStruct) loadInfo() error {
-	manager := storage.GetManager()
+	manager := storage.Manager()
 	infos, err := manager.LoadAllInfo()
 	if err != nil {
 		return err

--- a/sketches/manager_test.go
+++ b/sketches/manager_test.go
@@ -39,10 +39,10 @@ func setupTests() {
 
 func tearDownTests() {
 	storage.CloseInfoDB()
-	os.RemoveAll(config.GetConfig().GetDataDir())
-	os.RemoveAll(config.GetConfig().GetInfoDir())
-	os.Mkdir(config.GetConfig().GetDataDir(), 0777)
-	os.Mkdir(config.GetConfig().GetInfoDir(), 0777)
+	os.RemoveAll(config.GetConfig().DataDir)
+	os.RemoveAll(config.GetConfig().InfoDir)
+	os.Mkdir(config.GetConfig().DataDir, 0777)
+	os.Mkdir(config.GetConfig().InfoDir, 0777)
 	manager.Destroy()
 }
 

--- a/sketches/wrappers/count-min-log/sketch_test.go
+++ b/sketches/wrappers/count-min-log/sketch_test.go
@@ -24,10 +24,10 @@ func setupTests() {
 
 func tearDownTests() {
 	storage.CloseInfoDB()
-	os.RemoveAll(config.GetConfig().GetDataDir())
-	os.RemoveAll(config.GetConfig().GetInfoDir())
-	os.Mkdir(config.GetConfig().GetDataDir(), 0777)
-	os.Mkdir(config.GetConfig().GetInfoDir(), 0777)
+	os.RemoveAll(config.GetConfig().DataDir)
+	os.RemoveAll(config.GetConfig().InfoDir)
+	os.Mkdir(config.GetConfig().DataDir, 0777)
+	os.Mkdir(config.GetConfig().InfoDir, 0777)
 }
 
 func TestCMLCounter(t *testing.T) {

--- a/sketches/wrappers/dict/sketch_test.go
+++ b/sketches/wrappers/dict/sketch_test.go
@@ -24,10 +24,10 @@ func setupTests() {
 
 func tearDownTests() {
 	storage.CloseInfoDB()
-	os.RemoveAll(config.GetConfig().GetDataDir())
-	os.RemoveAll(config.GetConfig().GetInfoDir())
-	os.Mkdir(config.GetConfig().GetDataDir(), 0777)
-	os.Mkdir(config.GetConfig().GetInfoDir(), 0777)
+	os.RemoveAll(config.GetConfig().DataDir)
+	os.RemoveAll(config.GetConfig().InfoDir)
+	os.Mkdir(config.GetConfig().DataDir, 0777)
+	os.Mkdir(config.GetConfig().InfoDir, 0777)
 }
 
 func TestAddMultiple(t *testing.T) {

--- a/sketches/wrappers/topk/sketch.go
+++ b/sketches/wrappers/topk/sketch.go
@@ -33,7 +33,7 @@ type ResultElement topk.Element
 NewSketch ...
 */
 func NewSketch(info *abstract.Info) (*Sketch, error) {
-	manager = storage.GetManager()
+	manager = storage.Manager()
 	err := manager.Create(info.ID)
 	if err != nil {
 		logger.Error.Println("an error has occurred while creating sketch: " + err.Error())

--- a/storage/info_manager.go
+++ b/storage/info_manager.go
@@ -103,7 +103,7 @@ func getInfoDB() (*bolt.DB, error) {
 		return db, nil
 	}
 	var err error
-	infoDir := conf.GetInfoDir()
+	infoDir := conf.InfoDir
 	err = os.MkdirAll(infoDir, 0777)
 	if err != nil {
 		return nil, err

--- a/storage/manager.go
+++ b/storage/manager.go
@@ -25,8 +25,8 @@ var manager *ManagerStruct
 
 func newManager() *ManagerStruct {
 	conf = config.GetConfig()
-	dataPath = conf.GetDataDir()
-	cacheSize := int(conf.GetCacheSize())
+	dataPath = conf.DataDir
+	cacheSize := int(conf.CacheSize)
 	if cacheSize == 0 {
 		cacheSize = 250 // default cache size
 	}
@@ -44,9 +44,9 @@ func newManager() *ManagerStruct {
 }
 
 /*
-GetManager ...
+Manager ...
 */
-func GetManager() *ManagerStruct {
+func Manager() *ManagerStruct {
 	if manager == nil {
 		manager = newManager()
 	}

--- a/storage/manager_test.go
+++ b/storage/manager_test.go
@@ -24,10 +24,10 @@ func setupTests() {
 }
 
 func tearDownTests() {
-	os.RemoveAll(config.GetConfig().GetDataDir())
-	os.RemoveAll(config.GetConfig().GetInfoDir())
-	os.Mkdir(config.GetConfig().GetDataDir(), 0777)
-	os.Mkdir(config.GetConfig().GetInfoDir(), 0777)
+	os.RemoveAll(config.GetConfig().DataDir)
+	os.RemoveAll(config.GetConfig().InfoDir)
+	os.Mkdir(config.GetConfig().DataDir, 0777)
+	os.Mkdir(config.GetConfig().InfoDir, 0777)
 }
 
 func TestNoCounters(t *testing.T) {
@@ -138,7 +138,7 @@ func TestSaveAndDeleteData(t *testing.T) {
 	m := newManager()
 	m.Create("phoenix")
 	m.SaveData("phoenix", []byte("phoenix"), 0)
-	path := filepath.Join(config.GetConfig().GetDataDir(), "phoenix")
+	path := filepath.Join(config.GetConfig().DataDir, "phoenix")
 	if _, err := os.Stat(path); err != nil {
 		t.Error("Expected data in,", path, "got", err)
 	}


### PR DESCRIPTION
Refactored all Get methods from config.go, since the "Get" keyword is not necessary on Go.